### PR TITLE
feat!: update readme with latest version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ You need to manually map resources that the AWS Cloud Control API does not yet s
 The `AwsTerraformAdapter` currenly only supports TypeScript projects:
 
 - `aws-cdk-lib` >= 2.0.0 (requires `constructs` version 10)
-- `cdktf` >= 0.7.0
-- `@cdktf/aws-cdk` >= 0.1 (contains the adapter)
+- `cdktf` >= 0.8.0-pre.2 (pre-release version for 0.8)
+- `@cdktf/aws-cdk` >= 0.2 (contains the adapter)
 
 
 ```


### PR DESCRIPTION
this commit also bumps the adapter version to 0.2 as we now depend on cdktf 0.8.0-pre.2. In fact 0.1.11 already dependeded on that version
