### PR TITLE
fix: fixes handling AWS No:Value references

### DIFF
--- a/src/aws-adapter.ts
+++ b/src/aws-adapter.ts
@@ -354,6 +354,10 @@ class TerraformHost extends Construct {
         return this.awsCallerIdentity.accountId;
       }
 
+      case "AWS::NoValue": {
+        return undefined;
+      }
+
       default:
         throw new Error(`unable to resolve pseudo reference ${ref}`);
     }


### PR DESCRIPTION
Returned undefined so when the value gets processed it's handled safely

Fixes #97 