### PR TITLE
feat: add mapping for URL Suffix pseudo parameter reference

### DIFF
--- a/src/aws-adapter.ts
+++ b/src/aws-adapter.ts
@@ -356,6 +356,13 @@ class TerraformHost extends Construct {
         return undefined;
       }
 
+      case "AWS::URLSuffix": {
+        this.awsPartition =
+          this.awsPartition ??
+          new DataAwsPartition(this, "aws-partition");
+        return this.awsPartition.dnsSuffix;
+      }
+
       default:
         throw new Error(`unable to resolve pseudo reference ${ref}`);
     }

--- a/src/tests/aws-adapter.test.ts
+++ b/src/tests/aws-adapter.test.ts
@@ -16,6 +16,45 @@ describe("AwsTerraformAdapter", () => {
     adapter = new AwsTerraformAdapter(stack, "adapter");
   });
 
+  describe("resolvePseudo", () => {
+    it("should resolve AWS::URLSuffix", () => {
+      new StaticCfnConstruct(adapter, "cfn", {
+        Resources: {
+          subject: {
+            Type: "Test::Resource",
+            Properties: {
+              Value: { Ref: "AWS::URLSuffix" },
+            },
+          },
+          another: {
+            Type: "Test::Resource",
+            Properties: {},
+          },
+        },
+      });
+
+      expect(Testing.synth(stack)).toMatchInlineSnapshot(`
+        "{
+          \\"data\\": {
+            \\"aws_partition\\": {
+              \\"adapter_aws-partition_5B16AD9D\\": {
+              }
+            }
+          },
+          \\"resource\\": {
+            \\"test\\": {
+              \\"adapter_another_C86ABFE2\\": {
+              },
+              \\"adapter_subject_24E89D84\\": {
+                \\"value\\": \\"\${data.aws_partition.adapter_aws-partition_5B16AD9D.dns_suffix}\\"
+              }
+            }
+          }
+        }"
+      `);
+    });
+  });
+
   describe("resolveIntrinsic", () => {
     it("should resolve Fn::GetAtt", () => {
       new StaticCfnConstruct(adapter, "cfn", {


### PR DESCRIPTION
Related to #84 #91

Uses https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition#dns_suffix to map the `AWS::URLSuffix` pseudo parameter ref.

See https://github.com/hashicorp/cdktf-aws-cdk/issues/84#issuecomment-1144556604

FYI: haven't tested this for real so far