### PR TITLE
chore: pin additional GitHub Actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,9 +42,7 @@ jobs:
       - name: Clean up
         run: rm -rf .repo
       - name: Setup Copywrite tool
-        uses: hashicorp/setup-copywrite@3ace06ad72e6ec679ea8572457b17dbc3960b8ce
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        uses: hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e
       - name: Add headers using Copywrite tool
         run: copywrite headers
       - name: Find mutations
@@ -88,7 +86,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Download patch
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: .repo.patch
           path: ${{ runner.temp }}
@@ -115,7 +113,7 @@ jobs:
         with:
           node-version: 16.14.0
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/provider-upgrade.yml
+++ b/.github/workflows/provider-upgrade.yml
@@ -24,7 +24,7 @@ jobs:
       - run: yarn compile
       - run: yarn docgen
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04
+        uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666
         with:
           commit-message: "chore: upgrade provider"
           branch: auto/provider-upgrade

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           node-version: 16.14.0
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: build-artifact
           path: dist
@@ -104,7 +104,7 @@ jobs:
         with:
           node-version: 16.14.0
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84
         with:
           days-before-stale: -1
           days-before-close: -1

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set git config safe.directory
         run: git config --global --add safe.directory $(pwd)
       - name: Download patch
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: .repo.patch
           path: ${{ runner.temp }}
@@ -68,7 +68,7 @@ jobs:
           git config user.email "github-team-tf-cdk@hashicorp.com"
       - name: Create Pull Request
         id: create-pr
-        uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04
+        uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666
         with:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -8,12 +8,13 @@ import { CdktfAwsCdkProject } from "./projen";
 const githubActionPinnedVersions = {
   "actions/checkout": "8e5e7e5ab8b370d6c329ec480221332ada57f0ab", // v3.5.2
   "actions/upload-artifact": "0b7f8abb1508181956e8e162db84b466c27e18ce", // v3.1.2
+  "actions/download-artifact": "9bc31d5ccc31df68ecc42ccf4149144866c47d8a", // v3.0.2
   "dessant/lock-threads": "c1b35aecc5cdb1a34539d14196df55838bb2f836", // v4.0.0
   "amannn/action-semantic-pull-request":
     "c3cd5d1ea3580753008872425915e343e351ab54", // v5.2.0
   "actions/setup-node": "64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c", // v3.6.0
-  "actions/stale": "a20b814fb01b71def3bd6f56e7494d667ddf28da", // v4.1.1
-  "peter-evans/create-pull-request": "2b011faafdcbc9ceb11414d64d0573f37c774b04", // v4.2.3
+  "actions/stale": "1160a2240286f5da8ec72b1c0816ce2481aabf84", // v8.0.0
+  "peter-evans/create-pull-request": "284f54f989303d2699d373481a0cfa13ad5a6666", // v5.0.1
   "pascalgn/automerge-action": "22948e0bc22f0aa673800da838595a3e7347e584", // v0.15.6
 };
 

--- a/projen/index.ts
+++ b/projen/index.ts
@@ -229,8 +229,7 @@ export class CdktfAwsCdkProject extends cdk.JsiiProject {
     this.buildWorkflow?.addPostBuildSteps(
       {
         name: "Setup Copywrite tool",
-        uses: "hashicorp/setup-copywrite@3ace06ad72e6ec679ea8572457b17dbc3960b8ce", // v1.0.0
-        with: { token: "${{ secrets.GITHUB_TOKEN }}" },
+        uses: "hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e", // v1.1.2
       },
       { name: "Add headers using Copywrite tool", run: "copywrite headers" }
     );


### PR DESCRIPTION
Was auditing the repo today and noticed that `actions/download-artifact` was missing, and `actions/stale` has a newer version we can use. We can also update `setup-copywrite` to the newer version that no longer needs a token to be passed as an input.
