### PR TITLE
chore: add issue templates

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -11,5 +11,6 @@ project {
     # "vendors/**",
     # "**autogen**",
     "**/node_modules/**",
+    ".github/ISSUE_TEMPLATE/**",
   ]
 }

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,113 @@
+name: "🐛 Bug Report"
+description: "If something isn't working as expected 🤔"
+labels: [bug, new]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Note**
+        We use GitHub issues for tracking bugs and enhancements. For questions, please use [the community forum](https://discuss.hashicorp.com/c/terraform-core/cdk-for-terraform/47) where there are more people ready to help.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        A clear and concise description of the issue in plain English.
+        Feel free to include screenshots, but do NOT paste your full debug output here; link that in a GitHub Gist further down in this form.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: CDKTF AWS Adapter Version
+      description: |
+        What version of `@cdktf/aws-cdk` are you using? You can look this up using `npm list`.
+      placeholder: v0.8.3
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: AWS CDK Version
+      description: |
+        What version of `aws-cdk-lib` are you using? You can look this up using `npm list`.
+      placeholder: v2.80.0
+    validations:
+      required: true
+
+  - type: input
+    id: gist
+    attributes:
+      label: Gist
+      description: |
+        If possible, please provide a link to a [GitHub Gist](https://gist.github.com/) containing your complete debug output or anything else that would be helpful for reproducing your issue.
+      placeholder: |
+        https://gist.github.com/gdb/b6365e79be6052e7531e7ba6ea8caf23
+    validations:
+      required: false
+
+  - type: textarea
+    id: solutions
+    attributes:
+      label: Possible Solutions
+      description: |
+        Do you have any ideas or suggestions for how the issue might be resolved?
+    validations:
+      required: false
+
+  - type: textarea
+    id: workarounds
+    attributes:
+      label: Workarounds
+      description: |
+        Did you discover any workarounds on your own? If so, please list them here.
+    validations:
+      required: false
+
+  - type: textarea
+    id: miscellaneous
+    attributes:
+      label: Anything Else?
+      description: |
+        Is there anything else we should know? For example, is there anything atypical about your setup that could be affecting this issue?
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: |
+        Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Or links to documentation pages?
+        Guide to referencing Github issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
+      placeholder: |
+        - #123
+        - #456
+        - https://developer.hashicorp.com/terraform/cdktf/concepts/tokens
+        - https://docs.aws.amazon.com/cdk/v2/guide/tokens.html
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Help Wanted
+      description: Is this something you're able to or interested in helping out with? This is not required but a helpful way to signal to us that you're planning to open a PR with a fix.
+      options:
+        - label: I'm interested in contributing a fix myself
+          required: false
+
+  - type: textarea
+    id: community
+    attributes:
+      label: Community Note
+      description: Please do not remove, edit, or change the following note for our community. Just leave everything in this textbox as-is.
+      value: |
+        - Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+        - Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
+        - If you are interested in working on this issue or have submitted a pull request, please leave a comment
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/cloudcontrol-mapping.yml
+++ b/.github/ISSUE_TEMPLATE/cloudcontrol-mapping.yml
@@ -1,0 +1,63 @@
+name: "🗺 Request Cloud Control Mapping"
+description: "Make a request or suggestion for adding a manual mapping for an AWS resource not yet supported by the Cloud Control API"
+labels: [cloudcontrol, enhancement, help wanted]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Note**
+        We use GitHub issues for tracking bugs and enhancements. For questions, please use [the community forum](https://discuss.hashicorp.com/c/terraform-core/cdk-for-terraform/47) where there are more people ready to help.
+
+  - type: textarea
+    id: resources
+    attributes:
+      label: Resources
+      description: |
+        Which resource(s) are missing from [this list](https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/supported-resources.html) and do we need to add manual mappings for?
+      placeholder: |
+        - `AWS::S3::BucketPolicy`
+        - `AWS::Lambda::Alias`
+        - `AWS::Lambda::Version`
+    validations:
+      required: true
+
+  - type: textarea
+    id: constructs
+    attributes:
+      label: Constructs
+      description: Which AWS CDK Construct(s) were you trying to use when you encountered this limitation?
+      placeholder: |
+        - https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.RestApi.html
+        - https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.SpecRestApi.html
+    validations:
+      required: false
+
+  - type: textarea
+    id: usecase
+    attributes:
+      label: Use Case
+      description: Is there anything else that would be helpful to know about your use case?
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Help Wanted
+      description: Is this something you're able to or interested in helping out with? This is not required but a helpful way to signal to us that you're planning to open a PR with a fix.
+      options:
+        - label: I'm interested in contributing a fix myself
+          required: false
+
+  - type: textarea
+    id: community
+    attributes:
+      label: Community Note
+      description: Please do not remove, edit, or change the following note for our community. Just leave everything in this textbox as-is.
+      value: |
+        - Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+        - Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
+        - If you are interested in working on this issue or have submitted a pull request, please leave a comment
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Question
+    url: https://discuss.hashicorp.com/c/terraform-core/cdk-for-terraform/47
+    about: 🙋 For usage questions that may not require a core maintainer to answer, post in our community forum
+  - name: Terraform Cloud/Enterprise Troubleshooting
+    url: https://support.hashicorp.com/hc/en-us/requests/new
+    about: For issues related to the Terraform Cloud/Enterprise platform, please submit a HashiCorp support request or email tf-cloud@hashicorp.support

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,54 @@
+name: "📕 Documentation Issue"
+description: "👀 Report an issue our documentation or examples"
+labels: [documentation, new]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Note**
+        We use GitHub issues for tracking bugs and enhancements. For questions, please use [the community forum](https://discuss.hashicorp.com/c/terraform-core/cdk-for-terraform/47) where there are more people ready to help.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the issue in plain English.
+    validations:
+      required: true
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Links
+      description: |
+        Include links to affected or related documentation page(s) or issues.
+        Guide to referencing Github issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
+      placeholder: |
+        - https://developer.hashicorp.com/terraform/cdktf/concepts/tokens
+        - https://docs.aws.amazon.com/cdk/v2/guide/tokens.html
+        - #123
+        - #456
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Help Wanted
+      description: Is this something you're able to or interested in helping out with? This is not required but a helpful way to signal to us that you're planning to open a PR with a fix.
+      options:
+        - label: I'm interested in contributing a fix myself
+          required: false
+
+  - type: textarea
+    id: community
+    attributes:
+      label: Community Note
+      description: Please do not remove, edit, or change the following note for our community. Just leave everything in this textbox as-is.
+      value: |
+        - Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+        - Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
+        - If you are interested in working on this issue or have submitted a pull request, please leave a comment
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,54 @@
+name: "🚀 Feature Request"
+description: "I have a suggestion (and might want to implement myself 🙂)"
+labels: [enhancement, new]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Note**
+        We use GitHub issues for tracking bugs and enhancements. For questions, please use [the community forum](https://discuss.hashicorp.com/c/terraform-core/cdk-for-terraform/47) where there are more people ready to help.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the feature request in plain English.
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: |
+        Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Or links to documentation pages?
+        Guide to referencing Github issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
+      placeholder: |
+        - #123
+        - #456
+        - https://developer.hashicorp.com/terraform/cdktf/concepts/tokens
+        - https://docs.aws.amazon.com/cdk/v2/guide/tokens.html
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Help Wanted
+      description: Is this something you're able to or interested in helping out with? This is not required but a helpful way to signal to us that you're planning to open a PR with a fix.
+      options:
+        - label: I'm interested in contributing a fix myself
+          required: false
+
+  - type: textarea
+    id: community
+    attributes:
+      label: Community Note
+      description: Please do not remove, edit, or change the following note for our community. Just leave everything in this textbox as-is.
+      value: |
+        - Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+        - Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
+        - If you are interested in working on this issue or have submitted a pull request, please leave a comment
+    validations:
+      required: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,10 +21,10 @@ jobs:
           stale-pr-message: Hi there! 👋 We haven't heard from you in 60 days and would like to know if you're still working on this or need help. If we don't hear from you before then, I'll auto-close this PR in 30 days.
           close-pr-message: I'm closing this pull request because we haven't heard back in 90 days. ⌛️ If you're still working on this, feel free to reopen the PR or create a new one!
           stale-pr-label: stale
-          exempt-pr-labels: backlog
+          exempt-pr-labels: backlog,help wanted
           days-before-issue-stale: 30
           days-before-issue-close: 30
           stale-issue-message: Hi there! 👋 We haven't heard from you in 30 days and would like to know if the problem has been resolved or if you still need help. If we don't hear from you before then, I'll auto-close this issue in 30 days.
           close-issue-message: I'm closing this issue because we haven't heard back in 60 days. ⌛️ If you still need help, feel free to reopen the issue!
           stale-issue-label: stale
-          exempt-issue-labels: backlog
+          exempt-issue-labels: backlog,help wanted

--- a/.projen/jest-snapshot-resolver.js
+++ b/.projen/jest-snapshot-resolver.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: MPL-2.0
- */
-
 const path = require("path");
 const libtest = "lib/tests";
 const srctest= "src/tests";

--- a/.projen/jest-snapshot-resolver.js
+++ b/.projen/jest-snapshot-resolver.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 const path = require("path");
 const libtest = "lib/tests";
 const srctest= "src/tests";

--- a/projen/index.ts
+++ b/projen/index.ts
@@ -108,6 +108,7 @@ export class CdktfAwsCdkProject extends cdk.JsiiProject {
       stale: true,
       staleOptions: {
         issues: {
+          exemptLabels: ["backlog", "help wanted"],
           staleLabel: "stale",
           daysBeforeStale: 30,
           staleMessage:
@@ -118,6 +119,7 @@ export class CdktfAwsCdkProject extends cdk.JsiiProject {
             "I'm closing this issue because we haven't heard back in 60 days. ⌛️ If you still need help, feel free to reopen the issue!",
         },
         pullRequest: {
+          exemptLabels: ["backlog", "help wanted"],
           staleLabel: "stale",
           daysBeforeStale: 60,
           staleMessage:


### PR DESCRIPTION
Copied from hashicorp/terraform-cdk-action#50: I looked into whether there is a Projen-native way to generate issue templates and there's not (there only is for the pull request template), and translating our existing YAML templates into JavaScript so that Projen can compile it back into YAML seems silly. So, just adding in the YAML files and having them not be managed by Projen at all seemed like the best solution. IMO this also makes them easier to maintain in the future (for example, if we want to add a new field to an issue template in all our repos).