### PR TITLE
chore: improve dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  # Maintain dependencies for each example folder
+  - package-ecosystem: "npm"
+    directory: "/examples/typescript-cron-lambda"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "automerge"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "npm"
+    directory: "/examples/typescript-manual-mapping"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "automerge"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "npm"
+    directory: "/examples/typescript-step-functions"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "automerge"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "npm"
+    directory: "/examples/typescript-step-functions-mixed"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "automerge"
+    open-pull-requests-limit: 5

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -30,3 +30,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           MERGE_RETRIES: "20"
           MERGE_RETRY_SLEEP: "60000"
+          MERGE_METHOD: rebase

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -4,7 +4,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 * * 1
 jobs:
   upgrade:
     name: Upgrade
@@ -83,7 +83,7 @@ jobs:
             *Automatically created by projen via the "upgrade-main" workflow*
           branch: github-actions/upgrade-main
           title: "chore(deps): upgrade dependencies"
-          labels: dependencies
+          labels: automerge,dependencies
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 

--- a/.projen/jest-snapshot-resolver.js
+++ b/.projen/jest-snapshot-resolver.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: MPL-2.0
- */
-
 const path = require("path");
 const libtest = "lib/tests";
 const srctest= "src/tests";

--- a/.projen/jest-snapshot-resolver.js
+++ b/.projen/jest-snapshot-resolver.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 const path = require("path");
 const libtest = "lib/tests";
 const srctest= "src/tests";

--- a/projen/auto-merge.ts
+++ b/projen/auto-merge.ts
@@ -47,6 +47,7 @@ export class AutoMerge {
               GITHUB_TOKEN: '${{ secrets.GH_TOKEN }}',
               MERGE_RETRIES: '20',
               MERGE_RETRY_SLEEP: '60000',
+              MERGE_METHOD: 'rebase',
             },
           },
         ],

--- a/projen/index.ts
+++ b/projen/index.ts
@@ -11,6 +11,7 @@ import { CdktfConfig } from "./cdktf-config";
 import { CustomizedLicense } from "./customized-license";
 import { LockIssues } from "./lock-issues";
 import { ProviderUpgrade } from "./provider-upgrade";
+import { UpgradeDependenciesSchedule } from "projen/lib/javascript";
 
 export interface CdktfAwsCdkOptions extends Partial<cdk.JsiiProjectOptions> {
   readonly terraformProvider: string;
@@ -102,7 +103,8 @@ export class CdktfAwsCdkProject extends cdk.JsiiProject {
       },
       depsUpgradeOptions: {
         workflowOptions: {
-          labels: ["dependencies"],
+          labels: ["automerge", "dependencies"],
+          schedule: UpgradeDependenciesSchedule.WEEKLY,
         },
       },
       stale: true,


### PR DESCRIPTION
Some productivity enhancements around dependency updates.

Note that I know that Projen can manage Dependabot configs, however as far as I could tell from the (limited) docs, it doesn't support creating a Dependabot config like this with multiple subdirectories. So, I figured the manual route is just the easiest way to go.