### PR TITLE
chore: make auto-approve run on pull_request_target

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -2,7 +2,7 @@
 
 name: auto-approve
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - labeled
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - name: Checkout PR
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -24,4 +22,6 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Auto-approve PR
         if: contains(github.event.pull_request.labels.*.name, 'auto-approve')
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: gh pr review ${{ github.event.pull_request.number }} --approve

--- a/projen/auto-approve.ts
+++ b/projen/auto-approve.ts
@@ -16,7 +16,7 @@ export class AutoApprove {
     if (!workflow) throw new Error("no workflow defined");
 
     workflow.on({
-      pullRequest: {
+      pullRequestTarget: {
         types: [
           "opened",
           "labeled",
@@ -43,13 +43,13 @@ export class AutoApprove {
             name: "Auto-approve PR",
             if: "contains(github.event.pull_request.labels.*.name, 'auto-approve')",
             run: "gh pr review ${{ github.event.pull_request.number }} --approve",
+            env: {
+              GH_TOKEN: "${{ secrets.GH_TOKEN }}",
+            },
           },
         ],
         permissions: {
           contents: JobPermission.READ,
-        },
-        env: {
-          GH_TOKEN: "${{ secrets.GH_TOKEN }}",
         },
       },
     });


### PR DESCRIPTION
#198 still didn't work, after ending up in a Google rabbit hole it seems like the issue might be that because `dependabot` is the author of the PRs, even though it isn't coming from a fork, we still need `pull_request_target` here.