### PR TITLE
chore: fix various build issues

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -8,7 +8,6 @@ on:
       - labeled
       - ready_for_review
       - reopened
-      - synchronize
 jobs:
   approve:
     runs-on: ubuntu-latest

--- a/.github/workflows/provider-upgrade.yml
+++ b/.github/workflows/provider-upgrade.yml
@@ -7,12 +7,10 @@ on:
   workflow_dispatch: {}
 jobs:
   upgrade:
+    name: Upgrade Terraform providers
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
-      issues: write
-      contents: write
-      statuses: write
+      contents: read
     env:
       CI: "true"
       CHECKPOINT_DISABLE: "1"
@@ -26,8 +24,12 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666
         with:
-          commit-message: "chore: upgrade provider"
+          commit-message: "feat: upgrade providers"
           branch: auto/provider-upgrade
-          title: "chore: upgrade provider"
-          body: This PR upgrades provider to the latest version
+          title: "feat: upgrade providers"
+          body: This PR upgrades the AWS and Time providers to the latest version, which may or may not result in new features.
           labels: automerge
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          author: team-tf-cdk <github-team-tf-cdk@hashicorp.com>
+          committer: team-tf-cdk <github-team-tf-cdk@hashicorp.com>
+          signoff: true

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
           ref: main
+      - name: Ensure correct user
+        run: chown -R root /__w/cdktf-aws-cdk
       - name: Set git config safe.directory
         run: git config --global --add safe.directory $(pwd)
       - name: Setup Node.js
@@ -53,6 +55,8 @@ jobs:
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
           ref: main
+      - name: Ensure correct user
+        run: chown -R root /__w/cdktf-aws-cdk
       - name: Set git config safe.directory
         run: git config --global --add safe.directory $(pwd)
       - name: Download patch

--- a/projen/auto-approve.ts
+++ b/projen/auto-approve.ts
@@ -22,7 +22,6 @@ export class AutoApprove {
           "labeled",
           "ready_for_review",
           "reopened",
-          "synchronize",
         ],
       },
     });

--- a/projen/index.ts
+++ b/projen/index.ts
@@ -221,15 +221,17 @@ export class CdktfAwsCdkProject extends cdk.JsiiProject {
     const buildSteps = (this.buildWorkflow as any).preBuildSteps as JobStep[];
     const releaseSteps = (this.release as any).defaultBranch.workflow.jobs
       .release.steps;
+    const { upgrade, pr } = (this.upgradeWorkflow as any).workflows[0].jobs;
 
     buildSteps.push(setSafeDirectory);
     releaseSteps.splice(1, 0, setSafeDirectory);
-    buildSteps.push(ensureCorrectUser);
-    releaseSteps.splice(1, 0, ensureCorrectUser);
-
-    const { upgrade, pr } = (this.upgradeWorkflow as any).workflows[0].jobs;
     upgrade.steps.splice(1, 0, setSafeDirectory);
     pr.steps.splice(1, 0, setSafeDirectory);
+
+    buildSteps.push(ensureCorrectUser);
+    releaseSteps.splice(1, 0, ensureCorrectUser);
+    upgrade.steps.splice(1, 0, ensureCorrectUser);
+    pr.steps.splice(1, 0, ensureCorrectUser);
 
     this.buildWorkflow?.addPostBuildSteps(
       {

--- a/projen/provider-upgrade.ts
+++ b/projen/provider-upgrade.ts
@@ -22,10 +22,7 @@ export class ProviderUpgrade {
 
     workflow.addJobs({
       upgrade: {
-        env: {
-          CI: "true",
-          CHECKPOINT_DISABLE: "1",
-        },
+        name: "Upgrade Terraform providers",
         runsOn: ["ubuntu-latest"],
         steps: [
           {
@@ -43,19 +40,25 @@ export class ProviderUpgrade {
             name: "Create Pull Request",
             uses: "peter-evans/create-pull-request@v3",
             with: {
-              "commit-message": "chore: upgrade provider",
+              "commit-message": "feat: upgrade providers",
               branch: "auto/provider-upgrade",
-              title: "chore: upgrade provider",
-              body: "This PR upgrades provider to the latest version",
+              title: "feat: upgrade providers",
+              body:
+                "This PR upgrades the AWS and Time providers to the latest version, which may or may not result in new features.",
               labels: "automerge",
+              token: "${{ secrets.PROJEN_GITHUB_TOKEN }}",
+              author: "team-tf-cdk <github-team-tf-cdk@hashicorp.com>",
+              committer: "team-tf-cdk <github-team-tf-cdk@hashicorp.com>",
+              signoff: true,
             },
           },
         ],
+        env: {
+          CI: "true",
+          CHECKPOINT_DISABLE: "1",
+        },
         permissions: {
-          pullRequests: JobPermission.WRITE,
-          issues: JobPermission.WRITE,
-          contents: JobPermission.WRITE,
-          statuses: JobPermission.WRITE,
+          contents: JobPermission.READ,
         },
       },
     });


### PR DESCRIPTION
Fixes a few build-related issues:

- removes the `synchronize` trigger from the auto-approve workflow because it's obnoxious (re-approving the PR on every update)
- attempts to fix the `upgrade-main` workflow because it's still not working -- hopefully adding the `chown` does the trick
- attempts to get the `provider-upgrade` workflow working which also hasn't run in months due to a missing token