### PR TITLE
chore: do not update examples as part of script

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/examples/typescript-cron-lambda"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     labels:
       - "dependencies"
       - "automerge"
@@ -13,7 +13,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/examples/typescript-manual-mapping"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     labels:
       - "dependencies"
       - "automerge"
@@ -22,7 +22,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/examples/typescript-step-functions"
     schedule:
-      interval: "monthly"
+      interval: "daily"
     labels:
       - "dependencies"
       - "automerge"
@@ -31,7 +31,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/examples/typescript-step-functions-mixed"
     schedule:
-      interval: "monthly"
+      interval: "daily"
     labels:
       - "dependencies"
       - "automerge"

--- a/scripts/update-cdktf.sh
+++ b/scripts/update-cdktf.sh
@@ -13,14 +13,4 @@ yarn
 sed -i "s/cdktfVersion: ".*",/cdktfVersion: \"$CDKTF_VERSION\",/" "$PROJECT_ROOT/.projenrc.ts"
 npx projen
 
-echo "Updating examples"
-# Loop through all examples and update the cdktf version
-for example in $(find "$PROJECT_ROOT/examples" -mindepth 1 -maxdepth 1 -type d); do
-  echo "Updating example $example"
-  cd "$example"
-  yarn
-  yarn add -D cdktf-cli@$CDKTF_VERSION
-  yarn add cdktf@$CDKTF_VERSION
-done
-
 echo "Done"


### PR DESCRIPTION
This does not currently work because the examples have `@cdktf/aws-cdk` as a dependency which has a peer dependency on specific versions of `cdktf` and thus subsequent runs of `yarn install` / `npm install` complain about version mismatch. In other words: we need to publish & release a new version of `@cdktf/aws-cdk` _first_ before we can update the examples. However, now that we have Dependabot set up to manage dependency updates for the examples, Dependabot will create PRs to update these, so this step can be safely removed from the script.