### PR TITLE
chore: auto-close PRs with no changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     outputs:
       self_mutation_happened: ${{ steps.self_mutation.outputs.self_mutation_happened }}
     env:
@@ -70,6 +71,26 @@ jobs:
         with:
           name: build-artifact
           path: dist
+      - name: Check if anything was actually changed by this PR
+        id: check_files
+        env:
+          GH_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          PR_ID: ${{ github.event.pull_request.number }}
+        run: gh pr diff $PR_ID --name-only | grep . || echo 'no_changes=true' >> $GITHUB_OUTPUT
+      - name: Close the PR if empty
+        env:
+          GH_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          PR_ID: ${{ github.event.pull_request.number }}
+        if: steps.check_files.outputs.no_changes
+        run: gh pr close $PR_ID -d -c 'Closing this PR because there are no changes after the self-mutation.'
+      - name: Cancel the rest of the run if empty
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+        if: steps.check_files.outputs.no_changes
+        run: |-
+          gh run cancel $RUN_ID 
+          gh run watch $RUN_ID
     container:
       image: hashicorp/jsii-terraform
   self-mutation:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           PR_ID: ${{ github.event.pull_request.number }}
         if: steps.check_files.outputs.no_changes
-        run: gh pr close $PR_ID -d -c 'Closing this PR because there are no changes after the self-mutation.'
+        run: gh pr close $PR_ID -d
       - name: Cancel the rest of the run if empty
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           PR_ID: ${{ github.event.pull_request.number }}
-        run: gh pr diff $PR_ID --name-only | grep . || echo 'no_changes=true' >> $GITHUB_OUTPUT
+        run: gh pr diff $PR_ID | grep . || echo 'no_changes=true' >> $GITHUB_OUTPUT
       - name: Close the PR if empty
         env:
           GH_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/projen/index.ts
+++ b/projen/index.ts
@@ -263,5 +263,36 @@ export class CdktfAwsCdkProject extends cdk.JsiiProject {
         "examples/**",
       ],
     });
+
+    const buildWorkflow = this.tryFindObjectFile(".github/workflows/build.yml");
+    buildWorkflow?.addOverride("jobs.build.permissions", {
+      contents: "write",
+      actions: "write",
+    });
+    buildWorkflow?.addToArray("jobs.build.steps", {
+      name: "Check if anything was actually changed by this PR",
+      id: "check_files",
+      env: {
+        GH_TOKEN: "${{ secrets.PROJEN_GITHUB_TOKEN }}",
+        PR_ID: "${{ github.event.pull_request.number }}",
+      },
+      run: "gh pr diff $PR_ID --name-only | grep . || echo 'no_changes=true' >> $GITHUB_OUTPUT",
+    } as JobStep, {
+      name: "Close the PR if empty",
+      env: {
+        GH_TOKEN: "${{ secrets.PROJEN_GITHUB_TOKEN }}",
+        PR_ID: "${{ github.event.pull_request.number }}",
+      },
+      if: "steps.check_files.outputs.no_changes",
+      run: "gh pr close $PR_ID -d -c 'Closing this PR because there are no changes after the self-mutation.'",
+    } as JobStep, {
+      name: "Cancel the rest of the run if empty",
+      env: {
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
+        RUN_ID: "${{ github.run_id }}",
+      },
+      if: "steps.check_files.outputs.no_changes",
+      run: "gh run cancel $RUN_ID \ngh run watch $RUN_ID",
+    } as JobStep);
   }
 }

--- a/projen/index.ts
+++ b/projen/index.ts
@@ -276,7 +276,7 @@ export class CdktfAwsCdkProject extends cdk.JsiiProject {
         GH_TOKEN: "${{ secrets.PROJEN_GITHUB_TOKEN }}",
         PR_ID: "${{ github.event.pull_request.number }}",
       },
-      run: "gh pr diff $PR_ID --name-only | grep . || echo 'no_changes=true' >> $GITHUB_OUTPUT",
+      run: "gh pr diff $PR_ID | grep . || echo 'no_changes=true' >> $GITHUB_OUTPUT",
     } as JobStep, {
       name: "Close the PR if empty",
       env: {

--- a/projen/index.ts
+++ b/projen/index.ts
@@ -284,7 +284,7 @@ export class CdktfAwsCdkProject extends cdk.JsiiProject {
         PR_ID: "${{ github.event.pull_request.number }}",
       },
       if: "steps.check_files.outputs.no_changes",
-      run: "gh pr close $PR_ID -d -c 'Closing this PR because there are no changes after the self-mutation.'",
+      run: "gh pr close $PR_ID -d",
     } as JobStep, {
       name: "Cancel the rest of the run if empty",
       env: {


### PR DESCRIPTION
#211 finally fixed the `provider-upgrade` workflow that hadn't been working in months, but now a new problem appears: as you can see from #233, we're now getting PRs that wind up empty after the self-mutation step.

One option is to look into having the copyright header generation happen elsewhere in the process rather than in the build workflow, so that Projen correctly identifies that there aren't any changes. Long-term that might be the best solution but personally I don't have any ideas how to make that happen (in particular without forcing users to have HashiCorp's copywrite installed in order to run Projen).

In the short term, the best option is to add some steps to the build workflow to check whether all of the changes were undone after Projen's self-mutation, and to close the PR if so. (I really wish this feature were just built into Projen -- it kinda feels like it should be.)

In an ideal world these steps would happen in between `Fail build on mutation` and `Backup artifact permissions` so that we don't waste time uploading an artifact for a PR we might be about to close, but Projen makes it particularly difficult to modify the build workflow, so I couldn't figure out how to insert these steps in the ideal place. Still, this should at least accomplish the goal of closing empty PRs. The `gh run cancel` also ensures that we don't waste time running the `package-js` job.