### PR TITLE
chore: update snapshots in example tests

### DIFF
--- a/examples/typescript-cron-lambda/package.json
+++ b/examples/typescript-cron-lambda/package.json
@@ -8,7 +8,7 @@
     "compile": "tsc --pretty",
     "synth": "cdktf synth",
     "pretest": "npm run build",
-    "test": "jest",
+    "test": "jest --passWithNoTests --updateSnapshot",
     "pretest:ci": "npm install --legacy-peer-deps",
     "test:ci": "npm install --no-save \"../../dist/js/aws-cdk@$(node -e \"console.log(require('../../package.json').version)\").jsii.tgz\" && npm test"
   },

--- a/examples/typescript-manual-mapping/package.json
+++ b/examples/typescript-manual-mapping/package.json
@@ -8,7 +8,7 @@
     "compile": "tsc --pretty",
     "synth": "cdktf synth",
     "pretest": "npm run build",
-    "test": "jest",
+    "test": "jest --passWithNoTests --updateSnapshot",
     "pretest:ci": "npm install --legacy-peer-deps",
     "test:ci": "npm install --no-save \"../../dist/js/aws-cdk@$(node -e \"console.log(require('../../package.json').version)\").jsii.tgz\" && npm test"
   },

--- a/examples/typescript-step-functions-mixed/package.json
+++ b/examples/typescript-step-functions-mixed/package.json
@@ -8,7 +8,7 @@
     "compile": "tsc --pretty",
     "synth": "cdktf synth",
     "pretest": "npm run build",
-    "test": "jest",
+    "test": "jest --passWithNoTests --updateSnapshot",
     "pretest:ci": "npm install --legacy-peer-deps",
     "test:ci": "npm install --no-save \"../../dist/js/aws-cdk@$(node -e \"console.log(require('../../package.json').version)\").jsii.tgz\" && npm test"
   },

--- a/examples/typescript-step-functions/package.json
+++ b/examples/typescript-step-functions/package.json
@@ -8,7 +8,7 @@
     "compile": "tsc --pretty",
     "synth": "cdktf synth",
     "pretest": "npm run build",
-    "test": "jest",
+    "test": "jest --passWithNoTests --updateSnapshot",
     "pretest:ci": "npm install --legacy-peer-deps",
     "test:ci": "npm install --no-save \"../../dist/js/aws-cdk@$(node -e \"console.log(require('../../package.json').version)\").jsii.tgz\" && npm test"
   },


### PR DESCRIPTION
This will allow the Jest upgrade PRs (#389, #390, #394, #395) to pass.