### PR TITLE
chore(deps): remove dependency on node-fetch

### DIFF
--- a/.github/workflows/upgrade-node.yml
+++ b/.github/workflows/upgrade-node.yml
@@ -30,6 +30,10 @@ jobs:
           echo "CURRENT_NODEJS_VERSION_SHORT=$CURRENT_VERSION_SHORT" >> $GITHUB_ENV
           echo "value=$CURRENT_VERSION" >> $GITHUB_OUTPUT
           echo "short=$CURRENT_VERSION_SHORT" >> $GITHUB_OUTPUT
+      - name: Ensure we are using that version of Node.js in our build
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        with:
+          node-version: ${{ steps.current_version.outputs.value }}
       - name: Get the earliest supported Node.js version whose EOL date is at least a month away
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
         with:

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -73,11 +73,6 @@
       "type": "build"
     },
     {
-      "name": "node-fetch",
-      "version": "~2",
-      "type": "build"
-    },
-    {
       "name": "npm-check-updates",
       "version": "^16",
       "type": "build"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "jsii-docgen": "~9.0.0",
     "jsii-pacmak": "^1.87.0",
     "jsii-rosetta": "~5.1.2",
-    "node-fetch": "~2",
     "npm-check-updates": "^16",
     "projen": "^0.72.18",
     "standard-version": "^9",

--- a/projenrc/index.ts
+++ b/projenrc/index.ts
@@ -289,7 +289,6 @@ export class CdktfAwsCdkProject extends cdk.JsiiProject {
     new UpdateSnapshots(this);
     new UpgradeCDKTF(this);
     new UpgradeNode(this);
-    this.addDevDeps("node-fetch@~2"); // @TODO this can be removed once we upgrade to Node 18 and use native fetch
 
     const releaseWorkflow = this.tryFindObjectFile(".github/workflows/release.yml");
     releaseWorkflow?.addOverride("on.push", {

--- a/projenrc/upgrade-node.ts
+++ b/projenrc/upgrade-node.ts
@@ -49,6 +49,15 @@ export class UpgradeNode {
             ].join("\n"),
           },
           {
+            name: "Ensure we are using that version of Node.js in our build",
+            uses: "actions/setup-node@v3",
+            with: {
+              "node-version": "${{ steps.current_version.outputs.value }}",
+            },
+            // This step is required for now in order to remove the dependency on node-fetch
+            // In the future, when all GitHub Actions run on Node18+ by default, this can be removed
+          },
+          {
             name: "Get the earliest supported Node.js version whose EOL date is at least a month away",
             uses: "actions/github-script@v6",
             with: {

--- a/scripts/check-node-versions.js
+++ b/scripts/check-node-versions.js
@@ -2,8 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-const fetch = require("node-fetch"); // @TODO this can be removed once we upgrade to Node 18 and use native fetch
-
 const today = new Date();
 const oneMonthFromToday = new Date();
 oneMonthFromToday.setDate(today.getDate() + 30);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5981,13 +5981,6 @@ node-fetch@^2.6.12, node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@~2:
-  version "2.6.13"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.13.tgz#a20acbbec73c2e09f9007de5cda17104122e0010"
-  integrity sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==
-  dependencies:
-    whatwg-url "^5.0.0"
-
 node-gyp@^9.0.0:
   version "9.4.0"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-9.4.0.tgz#2a7a91c7cba4eccfd95e949369f27c9ba704f369"


### PR DESCRIPTION
Now that we've successfully upgraded to Node v18, we can use native fetch instead.