### PR TITLE
chore: remove charset from tsconfig files

### DIFF
--- a/examples/typescript-cron-lambda/tsconfig.json
+++ b/examples/typescript-cron-lambda/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
       "alwaysStrict": true,
-      "charset": "utf8",
       "declaration": true,
       "experimentalDecorators": true,
       "inlineSourceMap": true,

--- a/examples/typescript-manual-mapping/tsconfig.json
+++ b/examples/typescript-manual-mapping/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
       "alwaysStrict": true,
-      "charset": "utf8",
       "declaration": true,
       "experimentalDecorators": true,
       "inlineSourceMap": true,

--- a/examples/typescript-step-functions-mixed/tsconfig.json
+++ b/examples/typescript-step-functions-mixed/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
       "alwaysStrict": true,
-      "charset": "utf8",
       "declaration": true,
       "experimentalDecorators": true,
       "inlineSourceMap": true,

--- a/examples/typescript-step-functions/tsconfig.json
+++ b/examples/typescript-step-functions/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
       "alwaysStrict": true,
-      "charset": "utf8",
       "declaration": true,
       "experimentalDecorators": true,
       "inlineSourceMap": true,


### PR DESCRIPTION
This is a requirement to upgrade TypeScript to v5+