### PR TITLE
chore: remove hard-coded versions of jsii-docgen and rosetta

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -55,7 +55,6 @@
     },
     {
       "name": "jsii-docgen",
-      "version": "~9.0.0",
       "type": "build"
     },
     {
@@ -64,7 +63,7 @@
     },
     {
       "name": "jsii-rosetta",
-      "version": "~5.1.2",
+      "version": "^5.1.0",
       "type": "build"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -302,13 +302,13 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --upgrade --target=minor --filter=@aws-sdk/client-cloudformation,@types/debug,@types/jest,@types/node,constructs,jest,jest-junit,jsii-diff,jsii-pacmak,jsii,npm-check-updates,projen,standard-version,ts-node,typescript,change-case,codemaker,debug,aws-cdk-lib,cdktf"
+          "exec": "npm-check-updates --upgrade --target=minor --filter=@aws-sdk/client-cloudformation,@types/debug,@types/jest,@types/node,constructs,jest,jest-junit,jsii-diff,jsii-docgen,jsii-pacmak,jsii-rosetta,jsii,npm-check-updates,projen,standard-version,ts-node,typescript,change-case,codemaker,debug,aws-cdk-lib,cdktf"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @aws-sdk/client-cloudformation @types/debug @types/jest @types/node constructs jest jest-junit jsii-diff jsii-pacmak jsii npm-check-updates projen standard-version ts-node typescript change-case codemaker debug aws-cdk-lib cdktf"
+          "exec": "yarn upgrade @aws-sdk/client-cloudformation @types/debug @types/jest @types/node constructs jest jest-junit jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii npm-check-updates projen standard-version ts-node typescript change-case codemaker debug aws-cdk-lib cdktf"
         },
         {
           "exec": "npx projen"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jsii-diff": "^1.88.0",
     "jsii-docgen": "~9.0.0",
     "jsii-pacmak": "^1.88.0",
-    "jsii-rosetta": "~5.1.2",
+    "jsii-rosetta": "^5.1.0",
     "node-fetch": "~2",
     "npm-check-updates": "^16",
     "projen": "^0.72.26",

--- a/projenrc/index.ts
+++ b/projenrc/index.ts
@@ -163,9 +163,7 @@ export class CdktfAwsCdkProject extends cdk.JsiiProject {
 
     // Submodule documentation generation
     this.gitignore.exclude("API.md"); // ignore the old file, we now generate it in the docs folder
-    this.addDevDeps("jsii-docgen@~9.0.0");
-    this.addDevDeps("jsii-rosetta@~5.1.2");
-
+    this.addDevDeps("jsii-docgen");
     const docgen = this.addTask("docgen", {
       description: "Generate documentation for the project",
       steps: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1267,14 +1267,14 @@
     chalk "^4.1.2"
     semver "^7.5.4"
 
-"@jsii/spec@1.87.0", "@jsii/spec@^1.84.0", "@jsii/spec@^1.87.0":
+"@jsii/spec@1.87.0", "@jsii/spec@^1.87.0":
   version "1.87.0"
   resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.87.0.tgz#99b9dd12ed92120e79e645538620db0526a7ad7b"
   integrity sha512-fhTT3IYmjyRKvUUWffBIuGDVVfyKC+QfE1cMyExSHl7l6wk6unrxS8qsU23kaJ5bNQAnlc2+CE1HteY2SLbepg==
   dependencies:
     ajv "^8.12.0"
 
-"@jsii/spec@1.88.0", "@jsii/spec@^1.88.0":
+"@jsii/spec@1.88.0", "@jsii/spec@^1.84.0", "@jsii/spec@^1.88.0":
   version "1.88.0"
   resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.88.0.tgz#46216d3ca93872b4d878bb81f0cc7b28dc621c28"
   integrity sha512-Q6xirxPM06TRW0GcsHa+tzPZLwe9I+mFYx5BaNMimcv21u6bQnxfynZMgNhHqvLYCmP37HWg0SboUYTa5JROzw==
@@ -5326,19 +5326,7 @@ jsii-pacmak@^1.88.0:
     xmlbuilder "^15.1.1"
     yargs "^16.2.0"
 
-jsii-reflect@^1.84.0, jsii-reflect@^1.87.0:
-  version "1.87.0"
-  resolved "https://registry.yarnpkg.com/jsii-reflect/-/jsii-reflect-1.87.0.tgz#4302bdf1662ca09baa72fcf9216b987d1392e855"
-  integrity sha512-Gk+Kat0O/+OFw1Q85HEq1Beoc6o4lqWNp7v7wZKwLLs4JFrBGOu1cIurAwfk6sFaWD2R7q85jZKs3tEbPzZlrA==
-  dependencies:
-    "@jsii/check-node" "1.87.0"
-    "@jsii/spec" "^1.87.0"
-    chalk "^4"
-    fs-extra "^10.1.0"
-    oo-ascii-tree "^1.87.0"
-    yargs "^16.2.0"
-
-jsii-reflect@^1.88.0:
+jsii-reflect@^1.84.0, jsii-reflect@^1.88.0:
   version "1.88.0"
   resolved "https://registry.yarnpkg.com/jsii-reflect/-/jsii-reflect-1.88.0.tgz#d7f020db2621e8b672c082eea752c47153da5a63"
   integrity sha512-YYZTEQpayvwMDtRMCjgNraTFUqsj4/KEOE8ChvDCkpxv6aH89vpZSsAJM5ymhNLDHj4XZ2OW3XE0sNOz31NbvA==
@@ -5348,6 +5336,18 @@ jsii-reflect@^1.88.0:
     chalk "^4"
     fs-extra "^10.1.0"
     oo-ascii-tree "^1.88.0"
+    yargs "^16.2.0"
+
+jsii-reflect@^1.87.0:
+  version "1.87.0"
+  resolved "https://registry.yarnpkg.com/jsii-reflect/-/jsii-reflect-1.87.0.tgz#4302bdf1662ca09baa72fcf9216b987d1392e855"
+  integrity sha512-Gk+Kat0O/+OFw1Q85HEq1Beoc6o4lqWNp7v7wZKwLLs4JFrBGOu1cIurAwfk6sFaWD2R7q85jZKs3tEbPzZlrA==
+  dependencies:
+    "@jsii/check-node" "1.87.0"
+    "@jsii/spec" "^1.87.0"
+    chalk "^4"
+    fs-extra "^10.1.0"
+    oo-ascii-tree "^1.87.0"
     yargs "^16.2.0"
 
 jsii-rosetta@^1.87.0:
@@ -5386,7 +5386,26 @@ jsii-rosetta@^1.88.0:
     workerpool "^6.4.2"
     yargs "^16.2.0"
 
-jsii-rosetta@^5.1.9, jsii-rosetta@~5.1.2:
+jsii-rosetta@^5.1.0:
+  version "5.1.11"
+  resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-5.1.11.tgz#0beac0b3d07798e9a26bfb32012f4201371f26bb"
+  integrity sha512-kZfHby0gqmwvpGUOgFhevoge4Fek1+zdGYs+nb7SIhxJL8s5amdUEUXoUB8evB/0unMvINSjhMbyiW+8h2JG6Q==
+  dependencies:
+    "@jsii/check-node" "1.88.0"
+    "@jsii/spec" "^1.88.0"
+    "@xmldom/xmldom" "^0.8.10"
+    chalk "^4"
+    commonmark "^0.30.0"
+    fast-glob "^3.3.1"
+    jsii "~5.1.5"
+    semver "^7.5.4"
+    semver-intersect "^1.4.0"
+    stream-json "^1.8.0"
+    typescript "~5.1.6"
+    workerpool "^6.4.2"
+    yargs "^17.7.2"
+
+jsii-rosetta@^5.1.9:
   version "5.1.10"
   resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-5.1.10.tgz#90ff2d1f5909a60c3312310ca1ce10ca9e777b76"
   integrity sha512-8j4+IdVBgc4OB9UVjs7Mb6htq4/mYa4N0TyciE/GPas3T+PVXjtPaLzoW8m1WX4Oku/rUNnVMDLZ7TV8YH4PSQ==


### PR DESCRIPTION
This will allow them to be auto-updated in the future.