### PR TITLE
chore(ci): comment on test failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,13 @@ jobs:
         run: cd .repo && npx projen package:js
       - name: Run integration tests
         run: cd .repo && yarn examples:test
+      - name: Comment on failure
+        if: ${{ failure() && github.event.pull_request }}
+        env:
+          PR_ID: ${{ github.event.pull_request.number }}
+          GIT_BRANCH: ${{ github.event.pull_request.head.ref }}
+          GH_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+        run: gh pr comment $PR_ID --body "This test failure could mean that the snapshots need to be regenerated. Run \`git checkout $GIT_BRANCH\` followed by \`yarn test -- --passWithNoTests --updateSnapshot\` in the directory of the test that failed, and commit & push the results."
       - name: Clean up
         run: rm -rf .repo
       - name: Setup Copywrite tool

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,13 @@ jobs:
         run: cd .repo && npx projen package:js
       - name: Run integration tests
         run: cd .repo && yarn examples:test
+      - name: Comment on failure
+        if: ${{ failure() && github.event.pull_request }}
+        env:
+          PR_ID: ${{ github.event.pull_request.number }}
+          GIT_BRANCH: ${{ github.event.pull_request.head.ref }}
+          GH_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+        run: gh pr comment $PR_ID --body "This test failure could mean that the snapshots need to be regenerated. Run \`git checkout $GIT_BRANCH\` followed by \`yarn test -- --passWithNoTests --updateSnapshot\` in the directory of the test that failed, and commit & push the results."
       - name: Clean up
         run: rm -rf .repo
       - name: Check if version has already been tagged

--- a/projenrc/index.ts
+++ b/projenrc/index.ts
@@ -160,6 +160,16 @@ export class CdktfAwsCdkProject extends cdk.JsiiProject {
           run: "cd .repo && yarn examples:test",
         },
         {
+          name: "Comment on failure",
+          if: "${{ failure() && github.event.pull_request }}",
+          env: {
+            PR_ID: "${{ github.event.pull_request.number }}",
+            GIT_BRANCH: "${{ github.event.pull_request.head.ref }}",
+            GH_TOKEN: "${{ secrets.PROJEN_GITHUB_TOKEN }}",
+          },
+          run: `gh pr comment $PR_ID --body "This test failure could mean that the snapshots need to be regenerated. Run \\\`git checkout $GIT_BRANCH\\\` followed by \\\`yarn test -- --passWithNoTests --updateSnapshot\\\` in the directory of the test that failed, and commit & push the results."`,
+        },
+        {
           name: "Clean up",
           run: "rm -rf .repo",
         },


### PR DESCRIPTION
This is a quick follow-up to #831, which posts a comment with instructions on how to update the snapshots if a test does fail.