### PR TITLE
chore(ci): fix syntax for concurrency in workflows

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -8,7 +8,9 @@ on:
       - labeled
       - ready_for_review
       - reopened
-concurrency: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
 jobs:
   approve:
     runs-on: ubuntu-latest

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -9,7 +9,9 @@ on:
       - ready_for_review
       - reopened
       - synchronize
-concurrency: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
 jobs:
   automerge:
     runs-on: ubuntu-latest

--- a/.github/workflows/upgrade-cdktf.yml
+++ b/.github/workflows/upgrade-cdktf.yml
@@ -5,7 +5,8 @@ on:
   schedule:
     - cron: 42 */6 * * *
   workflow_dispatch: {}
-concurrency: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   upgrade:
     name: Upgrade CDKTF

--- a/.github/workflows/upgrade-node.yml
+++ b/.github/workflows/upgrade-node.yml
@@ -5,7 +5,8 @@ on:
   schedule:
     - cron: 28 5 * * *
   workflow_dispatch: {}
-concurrency: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   upgrade:
     name: Upgrade Node.js

--- a/projenrc/auto-approve.ts
+++ b/projenrc/auto-approve.ts
@@ -21,8 +21,10 @@ export class AutoApprove {
       },
     });
 
-    (workflow.concurrency as any) =
-      "${{ github.workflow }}-${{ github.head_ref }}";
+    (workflow.concurrency as any) = {
+      group: "${{ github.workflow }}-${{ github.head_ref }}",
+      cancelInProgress: true,
+    };
 
     const maintainerStatuses = `fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]')`;
     workflow.addJobs({

--- a/projenrc/automerge.ts
+++ b/projenrc/automerge.ts
@@ -27,8 +27,10 @@ export class Automerge {
       },
     });
 
-    (workflow.concurrency as any) =
-      "${{ github.workflow }}-${{ github.head_ref }}";
+    (workflow.concurrency as any) = {
+      group: "${{ github.workflow }}-${{ github.head_ref }}",
+      cancelInProgress: true,
+    };
 
     const maintainerStatuses = `fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]')`;
     workflow.addJobs({

--- a/projenrc/upgrade-cdktf.ts
+++ b/projenrc/upgrade-cdktf.ts
@@ -20,7 +20,9 @@ export class UpgradeCDKTF {
       workflowDispatch: {}, // allow manual triggering
     });
 
-    (workflow.concurrency as any) = "${{ github.workflow }}-${{ github.ref }}";
+    (workflow.concurrency as any) = {
+      group: "${{ github.workflow }}-${{ github.ref }}",
+    };
 
     workflow.addJobs({
       upgrade: {

--- a/projenrc/upgrade-node.ts
+++ b/projenrc/upgrade-node.ts
@@ -20,7 +20,9 @@ export class UpgradeNode {
       workflowDispatch: {}, // allow manual triggering
     });
 
-    (workflow.concurrency as any) = "${{ github.workflow }}-${{ github.ref }}";
+    (workflow.concurrency as any) = {
+      group: "${{ github.workflow }}-${{ github.ref }}",
+    };
 
     workflow.addJobs({
       upgrade: {


### PR DESCRIPTION
The auto-upgrade to Projen v0.85 broke a lot of our workflows overnight because of projen/projen#3762. This fixes it.