### PR TITLE
chore(ci): fix logic error in upgrade-node workflow

### DIFF
--- a/.github/workflows/upgrade-node.yml
+++ b/.github/workflows/upgrade-node.yml
@@ -41,22 +41,22 @@ jobs:
             const script = require('./scripts/check-node-versions.js')
             await script({github, context, core})
       - name: Run upgrade script
-        if: env.CURRENT_NODEJS_VERSION_SHORT != env.NEW_NODEJS_VERSION_SHORT
+        if: env.CURRENT_NODEJS_VERSION_SHORT < env.NEW_NODEJS_VERSION_SHORT
         run: scripts/update-node.sh $NEW_NODEJS_VERSION
       - name: Regenerate bindings
-        if: env.CURRENT_NODEJS_VERSION_SHORT != env.NEW_NODEJS_VERSION_SHORT
+        if: env.CURRENT_NODEJS_VERSION_SHORT < env.NEW_NODEJS_VERSION_SHORT
         run: yarn run fetch && yarn run compile
       - name: Update auto-generated docs
-        if: env.CURRENT_NODEJS_VERSION_SHORT != env.NEW_NODEJS_VERSION_SHORT
+        if: env.CURRENT_NODEJS_VERSION_SHORT < env.NEW_NODEJS_VERSION_SHORT
         run: yarn run docgen
       - name: Get values for pull request
         id: latest_version
-        if: env.CURRENT_NODEJS_VERSION_SHORT != env.NEW_NODEJS_VERSION_SHORT
+        if: env.CURRENT_NODEJS_VERSION_SHORT < env.NEW_NODEJS_VERSION_SHORT
         run: |-
           echo "value=$NEW_NODEJS_VERSION" >> $GITHUB_OUTPUT
           echo "short=$NEW_NODEJS_VERSION_SHORT" >> $GITHUB_OUTPUT
       - name: Create Pull Request
-        if: env.CURRENT_NODEJS_VERSION_SHORT != env.NEW_NODEJS_VERSION_SHORT
+        if: env.CURRENT_NODEJS_VERSION_SHORT < env.NEW_NODEJS_VERSION_SHORT
         uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e
         with:
           commit-message: "chore!: increase minimum supported Node.js version to ${{ steps.latest_version.outputs.short }}"

--- a/projenrc/upgrade-node.ts
+++ b/projenrc/upgrade-node.ts
@@ -67,23 +67,23 @@ export class UpgradeNode {
           },
           {
             name: "Run upgrade script",
-            if: "env.CURRENT_NODEJS_VERSION_SHORT != env.NEW_NODEJS_VERSION_SHORT",
+            if: "env.CURRENT_NODEJS_VERSION_SHORT < env.NEW_NODEJS_VERSION_SHORT",
             run: "scripts/update-node.sh $NEW_NODEJS_VERSION",
           },
           {
             name: "Regenerate bindings",
-            if: "env.CURRENT_NODEJS_VERSION_SHORT != env.NEW_NODEJS_VERSION_SHORT",
+            if: "env.CURRENT_NODEJS_VERSION_SHORT < env.NEW_NODEJS_VERSION_SHORT",
             run: "yarn run fetch && yarn run compile",
           },
           {
             name: "Update auto-generated docs",
-            if: "env.CURRENT_NODEJS_VERSION_SHORT != env.NEW_NODEJS_VERSION_SHORT",
+            if: "env.CURRENT_NODEJS_VERSION_SHORT < env.NEW_NODEJS_VERSION_SHORT",
             run: "yarn run docgen",
           },
           {
             name: "Get values for pull request",
             id: "latest_version",
-            if: "env.CURRENT_NODEJS_VERSION_SHORT != env.NEW_NODEJS_VERSION_SHORT",
+            if: "env.CURRENT_NODEJS_VERSION_SHORT < env.NEW_NODEJS_VERSION_SHORT",
             run: [
               `echo "value=$NEW_NODEJS_VERSION" >> $GITHUB_OUTPUT`,
               `echo "short=$NEW_NODEJS_VERSION_SHORT" >> $GITHUB_OUTPUT`,
@@ -91,7 +91,7 @@ export class UpgradeNode {
           },
           {
             name: "Create Pull Request",
-            if: "env.CURRENT_NODEJS_VERSION_SHORT != env.NEW_NODEJS_VERSION_SHORT",
+            if: "env.CURRENT_NODEJS_VERSION_SHORT < env.NEW_NODEJS_VERSION_SHORT",
             uses: "peter-evans/create-pull-request@v3",
             with: {
               "commit-message":


### PR DESCRIPTION
It shouldn't try to "upgrade" to Node 18 if it's already on Node 20.