### PR TITLE
chore(ci): attempt to fix token permission issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           PR_ID: ${{ github.event.pull_request.number }}
           GIT_BRANCH: ${{ github.event.pull_request.head.ref }}
-          GH_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr comment $PR_ID --body "This test failure could mean that the snapshots need to be regenerated. Run \`git checkout $GIT_BRANCH\` followed by \`yarn test -- --passWithNoTests --updateSnapshot\` in the directory of the test that failed, and commit & push the results."
       - name: Clean up
         run: rm -rf .repo
@@ -116,7 +116,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Download patch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           PR_ID: ${{ github.event.pull_request.number }}
           GIT_BRANCH: ${{ github.event.pull_request.head.ref }}
-          GH_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr comment $PR_ID --body "This test failure could mean that the snapshots need to be regenerated. Run \`git checkout $GIT_BRANCH\` followed by \`yarn test -- --passWithNoTests --updateSnapshot\` in the directory of the test that failed, and commit & push the results."
       - name: Clean up
         run: rm -rf .repo

--- a/projenrc/index.ts
+++ b/projenrc/index.ts
@@ -165,7 +165,7 @@ export class CdktfAwsCdkProject extends cdk.JsiiProject {
           env: {
             PR_ID: "${{ github.event.pull_request.number }}",
             GIT_BRANCH: "${{ github.event.pull_request.head.ref }}",
-            GH_TOKEN: "${{ secrets.PROJEN_GITHUB_TOKEN }}",
+            GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
           },
           run: `gh pr comment $PR_ID --body "This test failure could mean that the snapshots need to be regenerated. Run \\\`git checkout $GIT_BRANCH\\\` followed by \\\`yarn test -- --passWithNoTests --updateSnapshot\\\` in the directory of the test that failed, and commit & push the results."`,
         },
@@ -329,5 +329,6 @@ export class CdktfAwsCdkProject extends cdk.JsiiProject {
         run: "gh run cancel $RUN_ID \ngh run watch $RUN_ID",
       } as JobStep,
     );
+    buildWorkflow?.addDeletionOverride("jobs.self-mutation.steps.0.with.token");
   }
 }


### PR DESCRIPTION
Something about [Projen v0.87](https://github.com/projen/projen/releases/tag/v0.87.0) caused our workflows to stop working with Dependabot. Specifically, the Checkout step on the self-mutation job is failing with `Error: Input required and not supplied: token`.

I think this is because Dependabot does not have access to secrets like `PROJEN_GITHUB_TOKEN`, so the solution is to use the built-in `GITHUB_TOKEN` and making sure that one has the appropriate permissions configured. I'm not 100% positive this will work, but there's no way to find out without merging this and trying it.