### PR TITLE
chore(ci): do not run integration tests during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,23 +43,6 @@ jobs:
         run: yarn install --check-files --frozen-lockfile
       - name: release
         run: npx projen release
-      - name: Prepare Temporary Directory
-        run: cp -r dist .repo
-      - name: Install Dependencies
-        run: cd .repo && yarn install --check-files --frozen-lockfile
-      - name: Create js artifact
-        run: cd .repo && npx projen package:js
-      - name: Run integration tests
-        run: cd .repo && yarn examples:test
-      - name: Comment on failure
-        if: ${{ failure() && github.event.pull_request }}
-        env:
-          PR_ID: ${{ github.event.pull_request.number }}
-          GIT_BRANCH: ${{ github.event.pull_request.head.ref }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr comment $PR_ID --body "This test failure could mean that the snapshots need to be regenerated. Run \`git checkout $GIT_BRANCH\` followed by \`yarn test -- --passWithNoTests --updateSnapshot\` in the directory of the test that failed, and commit & push the results."
-      - name: Clean up
-        run: rm -rf .repo
       - name: Check if version has already been tagged
         id: check_tag_exists
         run: |-


### PR DESCRIPTION
It just makes the release job slower than it needs to be, and if the tests passed during a build, then they should always pass during release anyway.