### PR TITLE
chore(deps): pin eslint to v8

### DIFF
--- a/projenrc/cdktf-config.ts
+++ b/projenrc/cdktf-config.ts
@@ -37,8 +37,9 @@ export class CdktfConfig {
     // @see https://stackoverflow.com/a/72680434 for why this is necessary
     project.addDevDeps("ts-node@^10.9.1");
 
-    // @typescript-eslint v7+ requires Node.js 18.18, so we are stuck on v6
+    // eslint v9+ and @typescript-eslint v7+ require Node.js 18.18, so we are stuck on v6
     // The below lines can probably be removed once Node 18 goes EOL and we upgrade minNodeVersion to 20
+    project.addDevDeps("eslint@^8");
     project.addDevDeps("@typescript-eslint/eslint-plugin@^6");
     project.addDevDeps("@typescript-eslint/parser@^6");
 

--- a/projenrc/cdktf-config.ts
+++ b/projenrc/cdktf-config.ts
@@ -37,7 +37,7 @@ export class CdktfConfig {
     // @see https://stackoverflow.com/a/72680434 for why this is necessary
     project.addDevDeps("ts-node@^10.9.1");
 
-    // eslint v9+ and @typescript-eslint v7+ require Node.js 18.18, so we are stuck on v6
+    // eslint v9+ and @typescript-eslint v7+ require Node.js 18.18, so we are stuck on v8 and v6 respectively
     // The below lines can probably be removed once Node 18 goes EOL and we upgrade minNodeVersion to 20
     project.addDevDeps("eslint@^8");
     project.addDevDeps("@typescript-eslint/eslint-plugin@^6");


### PR DESCRIPTION
v9 requires Node 18.18+ while our minNodeVersion is purposely set to 18.12. The easiest fix is to avoid upgrading eslint for now.
