### PR TITLE
chore(deps): upgrade aws-cdk-lib in examples

### DIFF
--- a/examples/typescript-cron-lambda/package.json
+++ b/examples/typescript-cron-lambda/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@cdktf/aws-cdk": "^0.13.29",
-    "aws-cdk-lib": "2.93.0",
+    "aws-cdk-lib": "2.178.2",
     "cdktf": "0.20.11",
     "constructs": "10.4.2"
   },

--- a/examples/typescript-step-functions-mixed/main.test.ts
+++ b/examples/typescript-step-functions-mixed/main.test.ts
@@ -19,10 +19,6 @@ describe("typescript-state-machine", () => {
           "aws_partition": {
             "adapter_aws-partition_5B16AD9D": {
             }
-          },
-          "aws_region": {
-            "adapter_aws-region_F8878EF0": {
-            }
           }
         },
         "output": {
@@ -82,7 +78,7 @@ describe("typescript-state-machine", () => {
           },
           "aws_iam_role": {
             "adapter_StateMachineRoleB840431D_34E24F0D": {
-              "assume_role_policy": "\${jsonencode({\\"Statement\\" = [{\\"Action\\" = \\"sts:AssumeRole\\", \\"Effect\\" = \\"Allow\\", \\"Principal\\" = {\\"Service\\" = \\"ServiceprincipalMap\\"[data.aws_region.adapter_aws-region_F8878EF0.name].states}}], \\"Version\\" = \\"2012-10-17\\"})}"
+              "assume_role_policy": "\${jsonencode({\\"Statement\\" = [{\\"Action\\" = \\"sts:AssumeRole\\", \\"Effect\\" = \\"Allow\\", \\"Principal\\" = {\\"Service\\" = \\"states.amazonaws.com\\"}}], \\"Version\\" = \\"2012-10-17\\"})}"
             },
             "generate-id_server-role_62418FA4": {
               "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":[\\"sts:AssumeRole\\",\\"sts:SetSourceIdentity\\"],\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"Service\\":[\\"lambda.amazonaws.com\\"]}}]}",

--- a/examples/typescript-step-functions-mixed/package.json
+++ b/examples/typescript-step-functions-mixed/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@cdktf/aws-cdk": "^0.13.30",
-    "aws-cdk-lib": "2.93.0",
+    "aws-cdk-lib": "2.178.2",
     "cdktf": "0.20.11",
     "constructs": "10.4.2",
     "esbuild-wasm": "^0.25.0",

--- a/examples/typescript-step-functions/main.test.ts
+++ b/examples/typescript-step-functions/main.test.ts
@@ -19,10 +19,6 @@ describe("typescript-state-machine", () => {
           "aws_partition": {
             "adapter_aws-partition_5B16AD9D": {
             }
-          },
-          "aws_region": {
-            "adapter_aws-region_F8878EF0": {
-            }
           }
         },
         "provider": {
@@ -80,7 +76,7 @@ describe("typescript-state-machine", () => {
               ]
             },
             "adapter_StateMachineRoleB840431D_34E24F0D": {
-              "assume_role_policy": "\${jsonencode({\\"Statement\\" = [{\\"Action\\" = \\"sts:AssumeRole\\", \\"Effect\\" = \\"Allow\\", \\"Principal\\" = {\\"Service\\" = \\"ServiceprincipalMap\\"[data.aws_region.adapter_aws-region_F8878EF0.name].states}}], \\"Version\\" = \\"2012-10-17\\"})}"
+              "assume_role_policy": "\${jsonencode({\\"Statement\\" = [{\\"Action\\" = \\"sts:AssumeRole\\", \\"Effect\\" = \\"Allow\\", \\"Principal\\" = {\\"Service\\" = \\"states.amazonaws.com\\"}}], \\"Version\\" = \\"2012-10-17\\"})}"
             }
           },
           "aws_iam_role_policy_attachment": {

--- a/examples/typescript-step-functions/package.json
+++ b/examples/typescript-step-functions/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@cdktf/aws-cdk": "^0.13.29",
-    "aws-cdk-lib": "2.93.0",
+    "aws-cdk-lib": "2.178.2",
     "cdktf": "0.20.11",
     "constructs": "10.4.2"
   },


### PR DESCRIPTION
For some reason, Dependabot was regularly updating this dependency for `typescript-manual-mapping`, but not for the other 3 examples. I think manually upgrading all of them to the latest will spur Dependabot back into action for the other 3 going forward.

This resolves some low-level security warnings.