### PR TITLE
chore(deps): address security vulnerabilities

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -140,8 +140,23 @@
       "type": "bundled"
     },
     {
+      "name": "cookie",
+      "version": "0.7.0",
+      "type": "override"
+    },
+    {
+      "name": "cross-spawn",
+      "version": "7.0.6",
+      "type": "override"
+    },
+    {
       "name": "cssstyle",
       "version": "4.1.0",
+      "type": "override"
+    },
+    {
+      "name": "follow-redirects",
+      "version": "1.15.6",
       "type": "override"
     },
     {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,10 @@
     "debug"
   ],
   "resolutions": {
-    "cssstyle": "4.1.0"
+    "cookie": "0.7.0",
+    "cross-spawn": "7.0.6",
+    "cssstyle": "4.1.0",
+    "follow-redirects": "1.15.6"
   },
   "keywords": [
     "aws",

--- a/projenrc/cdktf-config.ts
+++ b/projenrc/cdktf-config.ts
@@ -46,6 +46,11 @@ export class CdktfConfig {
     // This is a temporary workaround to allow upgrade-main to succeed until we upgrade to Node 20
     project.package.addPackageResolutions(`cssstyle@4.1.0`);
 
+    // The following can be removed when upgrading to CDKTF 0.21
+    project.package.addPackageResolutions(`cookie@0.7.0`);
+    project.package.addPackageResolutions(`cross-spawn@7.0.6`);
+    project.package.addPackageResolutions(`follow-redirects@1.15.6`);
+
     // for update-supported-types script
     project.addDevDeps("@aws-sdk/client-cloudformation@^3.36.0");
     project.setScript(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3368,10 +3368,10 @@ convert-to-spaces@^1.0.1:
   resolved "https://registry.yarnpkg.com/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz#7e3e48bbe6d997b1417ddca2868204b4d3d85715"
   integrity sha512-cj09EBuObp9gZNQCzc7hByQyrs6jVGE+o9kSJmeUoj+GiPiJvi5LYqEH/Hmme4+MTLHM+Ejtq+FChpjjEnsPdQ==
 
-cookie@^0.4.1:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
-  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+cookie@0.7.0, cookie@^0.4.1:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.0.tgz#2148f68a77245d5c2c0005d264bc3e08cfa0655d"
+  integrity sha512-qCf+V4dtlNhSRXGAZatc1TasyFO6GjohcOul807YOb5ik3+kQSnb4d7iajeCL8QHaJ4uZEjCgiCJerKXwdRVlQ==
 
 core-util-is@^1.0.3, core-util-is@~1.0.0:
   version "1.0.3"
@@ -3416,16 +3416,7 @@ cross-fetch@3.1.8:
   dependencies:
     node-fetch "^2.6.12"
 
-cross-spawn@7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
-  dependencies:
-    path-key "^3.1.0"
-    shebang-command "^2.0.0"
-    which "^2.0.1"
-
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@7.0.3, cross-spawn@7.0.6, cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -4264,10 +4255,10 @@ flatted@^3.2.7, flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.2.tgz#adba1448a9841bec72b42c532ea23dbbedef1a27"
   integrity sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==
 
-follow-redirects@1.15.4:
-  version "1.15.4"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
-  integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
+follow-redirects@1.15.4, follow-redirects@1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
 for-each@^0.3.3:
   version "0.3.5"


### PR DESCRIPTION
There's a bunch of security alerts in this repo that can't/won't be fixed until CDKTF comes out with a 0.20.12 or even a 0.21.0 release. These all involve packages that are several layers deep (dependencies of dependencies of dependencies) to the point where it's quite possible this functionality really isn't used at all, but unfortunately the security scanners aren't smart enough to pick that up. The easiest (hacky but working) fix is to take advantage of Node's `packageResolutions` to hard-code these to the fixed versions. These overrides should be removed when we upgrade CDKTF.