### PR TITLE
chore(ci): remove unnecessary compile step from workflow

### DIFF
--- a/.github/workflows/upgrade-cdktf.yml
+++ b/.github/workflows/upgrade-cdktf.yml
@@ -23,10 +23,6 @@ jobs:
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 18.12.0
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
-        with:
-          terraform_wrapper: false
       - name: Install
         run: yarn install
       - name: Get current CDKTF version
@@ -49,12 +45,6 @@ jobs:
       - name: Run upgrade script
         if: steps.current_version.outputs.short != steps.latest_version.outputs.short
         run: scripts/update-cdktf.sh ${{ steps.latest_version.outputs.value }} ${{ steps.latest_version.outputs.constructs }}
-      - name: Regenerate bindings
-        if: steps.current_version.outputs.short != steps.latest_version.outputs.short
-        run: yarn run fetch && yarn run compile
-      - name: Update auto-generated docs
-        if: steps.current_version.outputs.short != steps.latest_version.outputs.short
-        run: yarn run docgen
       - name: Create Pull Request
         if: steps.current_version.outputs.short != steps.latest_version.outputs.short
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e

--- a/.github/workflows/upgrade-jsii-typescript.yml
+++ b/.github/workflows/upgrade-jsii-typescript.yml
@@ -3,7 +3,7 @@
 name: upgrade-jsii-typescript
 on:
   schedule:
-    - cron: 07 13 * * *
+    - cron: 34 13 * * *
   workflow_dispatch:
     inputs:
       version:
@@ -33,6 +33,7 @@ jobs:
       - name: Install
         run: yarn install
       - name: Get current JSII version
+        id: current_version
         run: |-
           CURRENT_VERSION=$(npm list jsii --depth=0 --json | jq -r '.dependencies.jsii.version')
           CURRENT_VERSION_SHORT=$(cut -d "." -f 1,2 <<< "$CURRENT_VERSION")

--- a/.github/workflows/upgrade-node.yml
+++ b/.github/workflows/upgrade-node.yml
@@ -3,7 +3,7 @@
 name: upgrade-node
 on:
   schedule:
-    - cron: 28 5 * * *
+    - cron: 34 10 * * *
   workflow_dispatch:
     inputs:
       version:
@@ -84,18 +84,10 @@ jobs:
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: ${{ needs.version.outputs.latest }}
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
-        with:
-          terraform_wrapper: false
       - name: Install
         run: yarn install
       - name: Run upgrade script
         run: scripts/update-node.sh ${{ needs.version.outputs.latest }}
-      - name: Regenerate bindings
-        run: yarn run fetch && yarn run compile
-      - name: Update auto-generated docs
-        run: yarn run docgen
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:

--- a/projenrc/upgrade-cdktf.ts
+++ b/projenrc/upgrade-cdktf.ts
@@ -41,13 +41,6 @@ export class UpgradeCDKTF {
             },
           },
           {
-            name: "Setup Terraform",
-            uses: "hashicorp/setup-terraform",
-            with: {
-              terraform_wrapper: false,
-            },
-          },
-          {
             name: "Install",
             run: "yarn install",
           },
@@ -81,16 +74,6 @@ export class UpgradeCDKTF {
             name: "Run upgrade script",
             if: "steps.current_version.outputs.short != steps.latest_version.outputs.short",
             run: "scripts/update-cdktf.sh ${{ steps.latest_version.outputs.value }} ${{ steps.latest_version.outputs.constructs }}",
-          },
-          {
-            name: "Regenerate bindings",
-            if: "steps.current_version.outputs.short != steps.latest_version.outputs.short",
-            run: "yarn run fetch && yarn run compile",
-          },
-          {
-            name: "Update auto-generated docs",
-            if: "steps.current_version.outputs.short != steps.latest_version.outputs.short",
-            run: "yarn run docgen",
           },
           {
             name: "Create Pull Request",

--- a/projenrc/upgrade-jsii-typescript.ts
+++ b/projenrc/upgrade-jsii-typescript.ts
@@ -5,6 +5,7 @@
 
 import { javascript } from "projen";
 import { JobPermission } from "projen/lib/github/workflows-model";
+import { generateRandomCron } from "./util/random-cron";
 
 /**
  * Helper script for upgrading JSII and TypeScript in the right way.
@@ -19,7 +20,8 @@ export class UpgradeJSIIAndTypeScript {
 
     const plainVersion = typescriptVersion.replace("~", "");
     workflow.on({
-      schedule: [{ cron: "07 13 * * *" }], // Runs once a day
+      // run daily sometime between 8am and 4pm UTC
+      schedule: [{ cron: generateRandomCron({ project, maxHour: 6, hourOffset: 8 }) }],
       workflowDispatch: {
         inputs: {
           version: {
@@ -57,6 +59,7 @@ export class UpgradeJSIIAndTypeScript {
           },
           {
             name: "Get current JSII version",
+            id: "current_version",
             run: [
               `CURRENT_VERSION=$(npm list jsii --depth=0 --json | jq -r '.dependencies.jsii.version')`,
               `CURRENT_VERSION_SHORT=$(cut -d "." -f 1,2 <<< "$CURRENT_VERSION")`,

--- a/projenrc/upgrade-jsii-typescript.ts
+++ b/projenrc/upgrade-jsii-typescript.ts
@@ -21,7 +21,9 @@ export class UpgradeJSIIAndTypeScript {
     const plainVersion = typescriptVersion.replace("~", "");
     workflow.on({
       // run daily sometime between 8am and 4pm UTC
-      schedule: [{ cron: generateRandomCron({ project, maxHour: 6, hourOffset: 8 }) }],
+      schedule: [
+        { cron: generateRandomCron({ project, maxHour: 6, hourOffset: 8 }) },
+      ],
       workflowDispatch: {
         inputs: {
           version: {

--- a/projenrc/upgrade-node.ts
+++ b/projenrc/upgrade-node.ts
@@ -19,7 +19,9 @@ export class UpgradeNode {
 
     workflow.on({
       // run daily sometime between 5 and 11am UTC
-      schedule: [{ cron: generateRandomCron({ project, maxHour: 6, hourOffset: 5 }) }],
+      schedule: [
+        { cron: generateRandomCron({ project, maxHour: 6, hourOffset: 5 }) },
+      ],
       workflowDispatch: {
         inputs: {
           version: {


### PR DESCRIPTION
This is very similar to cdktf/cdktf-provider-project#493. It turns out we were making these workflows a lot slower and more complicated than they needed to be by including the compilation and doc generation steps here, when we could just let the build workflow take care of that.